### PR TITLE
Warning, instead of exception, on temporary image existence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.fabric8</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.31-SNAPSHOT</version>
+  <version>0.32-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>docker-maven-plugin</name>

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -16,6 +16,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
@@ -471,7 +473,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
             throws DockerAccessException {
         ImageName name = new ImageName(image);
         String pushUrl = urlBuilder.pushImage(name, registry);
-        String temporaryImage = tagTemporaryImage(name, registry);
+        TemporaryImageHandler temporaryImageHandler = tagTemporaryImage(name, registry);
         DockerAccessException dae = null;
         try {
             doPushImage(pushUrl, createAuthHeader(authConfig), createPullOrPushResponseHandler(), HTTP_OK, retries);
@@ -479,15 +481,7 @@ public class DockerAccessWithHcClient implements DockerAccess {
             dae = new DockerAccessException(e, "Unable to push '%s'%s", image, (registry != null) ? " to registry '" + registry + "'" : "");
             throw dae;
         } finally {
-            if (temporaryImage != null) {
-                if (!removeImage(temporaryImage, true)) {
-                    if (dae == null) {
-                        throw new DockerAccessException("Image %s could be pushed, but the temporary tag could not be removed", temporaryImage);
-                    } else {
-                        throw new DockerAccessException(dae.getCause(), dae.getMessage() + " and also temporary tag [%s] could not be removed, too.", temporaryImage);
-                    }
-                }
-            }
+            temporaryImageHandler.handle(dae);
         }
     }
 
@@ -704,19 +698,26 @@ public class DockerAccessWithHcClient implements DockerAccess {
         }
     }
 
-    private String tagTemporaryImage(ImageName name, String registry) throws DockerAccessException {
+    private TemporaryImageHandler tagTemporaryImage(ImageName name, String registry) throws DockerAccessException {
         String targetImage = name.getFullName(registry);
-        if (!name.hasRegistry() && registry != null) {
-            if (hasImage(targetImage)) {
-                throw new DockerAccessException(
-                    String.format("Cannot temporarily tag %s with %s because target image already exists. " +
-                                  "Please remove this and retry.",
-                                  name.getFullName(), targetImage));
-            }
-            tag(name.getFullName(), targetImage, false);
-            return targetImage;
+        if (name.hasRegistry() || registry == null) {
+            return interruptingError ->
+                log.info("Temporary image tag skipped. Target image '%s' already has registry set or no registry is available");
         }
-        return null;
+
+        String fullName = name.getFullName();
+        boolean alreadyHasImage = hasImage(targetImage);
+
+        if (alreadyHasImage) {
+            log.warn("Target image '%s' already exists. Tagging of '%s' will replace existing image",
+                targetImage, fullName);
+        }
+
+        tag(fullName, targetImage, false);
+        return alreadyHasImage ?
+            interruptingError ->
+                log.info("Image '%s' won't be removed after tagging as it already existed", targetImage) :
+            new RemovingTemporaryImageHandler(targetImage);
     }
 
     // ===========================================================================================================
@@ -773,6 +774,38 @@ public class DockerAccessWithHcClient implements DockerAccess {
         try (CloseableHttpResponse response = delegate.getHttpClient().execute(get)) {
 
             return response.getFirstHeader("Api-Version") != null ? response.getFirstHeader("Api-Version").getValue() : API_VERSION;
+        }
+    }
+
+    @FunctionalInterface
+    private interface TemporaryImageHandler {
+        void handle(@Nullable DockerAccessException interruptingError) throws DockerAccessException;
+    }
+
+    private final class RemovingTemporaryImageHandler implements TemporaryImageHandler {
+        private final String targetImage;
+
+        private RemovingTemporaryImageHandler(String targetImage) {
+            this.targetImage = targetImage;
+        }
+
+        @Override
+        public void handle(@Nullable DockerAccessException interruptingError) throws DockerAccessException {
+            if (removeImage(targetImage, true)) {
+                return;
+            }
+            if (interruptingError == null) {
+                throw new DockerAccessException(
+                    "Image %s could be pushed, but the temporary tag could not be removed",
+                    targetImage
+                );
+            } else {
+                throw new DockerAccessException(
+                    interruptingError.getCause(),
+                    interruptingError.getMessage() + " and also temporary tag [%s] could not be removed, too.",
+                    targetImage
+                );
+            }
         }
     }
 }

--- a/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
+++ b/src/main/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClient.java
@@ -781,15 +781,15 @@ public class DockerAccessWithHcClient implements DockerAccess {
     private interface TemporaryImageHandler {
         void handle() throws DockerAccessException;
 
-		default void handle(@Nullable DockerAccessException interruptingError) throws DockerAccessException {
-			handle();
+        default void handle(@Nullable DockerAccessException interruptingError) throws DockerAccessException {
+            handle();
 
-			if (interruptingError == null) {
-				return;
-			}
-			throw interruptingError;
-		}
-	}
+            if (interruptingError == null) {
+                return;
+            }
+            throw interruptingError;
+        }
+    }
 
     private final class RemovingTemporaryImageHandler implements TemporaryImageHandler {
 		private final String targetImage;

--- a/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -18,19 +18,25 @@ import io.fabric8.maven.docker.util.Logger;
 import mockit.Expectations;
 import mockit.Mocked;
 
+import mockit.Verifications;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.ResponseHandler;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
 import static org.junit.Assert.*;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 
 public class DockerAccessWithHcClientTest {
+
+    private static final String BASE_URL = "tcp://1.2.3.4:2375";
 
     private AuthConfig authConfig;
 
@@ -57,12 +63,46 @@ public class DockerAccessWithHcClientTest {
 
     @Before
     public void setup() throws IOException {
-        client = new DockerAccessWithHcClient("tcp://1.2.3.4:2375", null, 1, mockLogger) {
+        client = new DockerAccessWithHcClient(BASE_URL, null, 1, mockLogger) {
             @Override
             ApacheHttpClientDelegate createHttpClient(ClientBuilder builder) throws IOException {
                 return mockDelegate;
             }
         };
+    }
+
+    @Test
+    public void testPushImageWithReplacementOfExistingOfTheSameTag_notRemoved() throws Exception {
+        String image = "test-image";
+        String tag = "test-tag";
+        String taggedImageName = String.format("%s:%s", image, tag);
+
+        givenAnImageName(taggedImageName);
+        givenRegistry("test-registry");
+        givenThatGetWillSucceedWithOk();
+
+        whenPushImage();
+
+        thenAlreadyHasImageMessageIsLogged();
+        thenImageWasTagged(image, tag);
+        thenPushSucceeded(image, tag);
+    }
+
+    @Test
+    public void testPushImageWithReplacementOfExistingOfTheSameTag_removed() throws Exception {
+        String image = "test-image";
+        String tag = "test-tag";
+        String taggedImageName = String.format("%s:%s", image, tag);
+
+        givenAnImageName(taggedImageName);
+        givenRegistry("test-registry");
+        givenThatGetWillSucceedWithNotFound();
+        givenThatDeleteWillSucceed();
+
+        whenPushImage();
+
+        thenImageWasTagged(image, tag);
+        thenPushSucceeded(image, tag);
     }
 
     @Test
@@ -166,6 +206,10 @@ public class DockerAccessWithHcClientTest {
         this.imageName = imageName;
     }
 
+    private void givenRegistry(String registry) {
+        this.registry = registry;
+    }
+
     private void givenANumberOfRetries(int retries) {
         this.pushRetries = retries;
     }
@@ -242,6 +286,22 @@ public class DockerAccessWithHcClientTest {
         }};
     }
 
+    @SuppressWarnings("unchecked")
+    private void givenThatGetWillSucceedWithOk() throws IOException {
+        new Expectations() {{
+            mockDelegate.get(anyString, (ResponseHandler<Integer>) any, HTTP_OK, HTTP_NOT_FOUND);
+            result = HTTP_OK;
+        }};
+    }
+
+    @SuppressWarnings("unchecked")
+    private void givenThatGetWillSucceedWithNotFound() throws IOException {
+        new Expectations() {{
+            mockDelegate.get(anyString, (ResponseHandler<Integer>) any, HTTP_OK, HTTP_NOT_FOUND);
+            result = HTTP_NOT_FOUND;
+        }};
+    }
+
     private void givenTheGetWillFail() throws IOException {
         new Expectations() {{
             mockDelegate.get(anyString, (ResponseHandler) any, 200);
@@ -256,12 +316,51 @@ public class DockerAccessWithHcClientTest {
         }};
     }
 
+    @SuppressWarnings("unchecked")
+    private void givenThatDeleteWillSucceed() throws IOException {
+        new Expectations() {{
+            mockDelegate.delete(anyString, (ResponseHandler<ApacheHttpClientDelegate.HttpBodyAndStatus>) any, HTTP_OK,
+                HTTP_NOT_FOUND);
+            result = new ApacheHttpClientDelegate.HttpBodyAndStatus(HTTP_OK, anyString);
+        }};
+    }
+
     private void thenImageWasNotPushed() {
         assertNotNull(thrownException);
     }
 
     private void thenImageWasPushed() {
        assertNull(thrownException);
+    }
+
+    private void thenPushSucceeded(String imageNameWithoutTag, String tag) throws IOException {
+        new Verifications() {{
+            String url;
+            mockDelegate.post(url = withCapture(), null, (Map<String, String>) any, (ResponseHandler<Object>) any,
+                HTTP_OK);
+
+            String expectedUrl = String.format("%s/vnull/images/%s%%2F%s/push?force=1&tag=%s", BASE_URL, registry,
+                imageNameWithoutTag, tag);
+            assertEquals(expectedUrl, url);
+        }};
+    }
+
+    private void thenAlreadyHasImageMessageIsLogged() {
+        new Verifications() {{
+            mockLogger.warn("Target image '%s' already exists. Tagging of '%s' will replace existing image",
+                getImageNameWithRegistry(), imageName);
+        }};
+    }
+
+    private void thenImageWasTagged(String imageNameWithoutTag, String tag) throws IOException {
+        new Verifications() {{
+            String url;
+            mockDelegate.post(url = withCapture(), HTTP_CREATED);
+
+            String expectedUrl = String.format("%s/vnull/images/%s%%3A%s/tag?force=0&repo=%s%%2F%s&tag=%s", BASE_URL,
+                imageNameWithoutTag, tag, registry, imageNameWithoutTag, tag);
+            assertEquals(expectedUrl, url);
+        }};
     }
 
     private void whenListContainers() {
@@ -341,5 +440,9 @@ public class DockerAccessWithHcClientTest {
             assertEquals(idRepoTagPairs[i].getLeft(), this.images.get(i).getId());
             assertEquals(Collections.singletonList(idRepoTagPairs[i].getRight()), this.images.get(i).getRepoTags());
         }
+    }
+
+    private String getImageNameWithRegistry() {
+        return registry + "/" + imageName;
     }
 }

--- a/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
+++ b/src/test/java/io/fabric8/maven/docker/access/hc/DockerAccessWithHcClientTest.java
@@ -72,7 +72,7 @@ public class DockerAccessWithHcClientTest {
     }
 
     @Test
-    public void testPushImageWithReplacementOfExistingOfTheSameTag_notRemoved() throws Exception {
+    public void testPushImage_replacementOfExistingOfTheSameTag() throws Exception {
         String image = "test-image";
         String tag = "test-tag";
         String taggedImageName = String.format("%s:%s", image, tag);
@@ -89,7 +89,7 @@ public class DockerAccessWithHcClientTest {
     }
 
     @Test
-    public void testPushImageWithReplacementOfExistingOfTheSameTag_removed() throws Exception {
+    public void testPushImage_imageOfTheSameTagDoesNotExist() throws Exception {
         String image = "test-image";
         String tag = "test-tag";
         String taggedImageName = String.format("%s:%s", image, tag);


### PR DESCRIPTION
After these changes 3 modes for handling of temporary images will be allowed:
- image of expected tag DO exists - it is already pulled so image of that tag will be updated and NOT removed after build,
- image of expected tag DOES NOT exist - it is treated as temporary image, so remove it after tagging process,
- image push to registry failed - image is not removed, because build was successful